### PR TITLE
Loosen gemspec dependencies to be within the same major version

### DIFF
--- a/pivotal-api.gemspec
+++ b/pivotal-api.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'rake', '~> 10.4.2'
+  spec.add_development_dependency 'rake', '~> 10.4'
 
-  spec.add_dependency 'addressable', '~> 2.3.7'
-  spec.add_dependency 'virtus', '~> 1.0.4'
-  spec.add_dependency 'faraday', '~> 0.9.1'
-  spec.add_dependency 'faraday_middleware', '~> 0.9.1'
-  spec.add_dependency 'excon', '~> 0.45.3'
+  spec.add_dependency 'addressable', '~> 2.3'
+  spec.add_dependency 'virtus', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency 'faraday_middleware', '~> 0.9'
+  spec.add_dependency 'excon', '~> 0.45'
 end


### PR DESCRIPTION
Currently the gemspec places very strict version requirements for its dependencies. This PR loosens these requirements to only restrict dependencies to be within the same major version rather than within the same minor version. The reason I want to do this is because the current/stricter gemspec requirements prevent this gem from being used in projects that use some of these dependencies at a higher minor version.